### PR TITLE
[leica/imx_v2020.04_5.4.24_2.1.0/crocodile]: imx8mm: config: fix fit configuration

### DIFF
--- a/include/configs/imx8mm_evk.h
+++ b/include/configs/imx8mm_evk.h
@@ -186,7 +186,7 @@
 		"sf read ${initrd_addr} 0x200000 0x1600000; "\
 		"bootm ${initrd_addr};\0" \
 	"swu=1\0" \
-	"fit_config=conf@freescale_crocodile.dtb\0"
+	"fit_config=conf-freescale_crocodile.dtb\0"
 
 #ifndef CONFIG_FSPI_NOR_BOOTFLOW
 #define CONFIG_BOOTCOMMAND \


### PR DESCRIPTION
Configuration naming of fitimages has changed in
`meta/classes/kernel-fitimage.bbclass` in OE-core.
Adjust to it.

https://git.yoctoproject.org/cgit/cgit.cgi/poky/commit/meta?id=cfc0e21b1066b5d5d0fc37fbc5d79f40f4576f1d