### PR TITLE
[leica/imx_v2020.04_5.4.24_2.1.0/dragonstaff]: imx8mm-var-dart: config: fix fit configuration

### DIFF
--- a/include/configs/imx8mm_var_dart.h
+++ b/include/configs/imx8mm_var_dart.h
@@ -176,7 +176,7 @@
 		"sf read ${initrd_addr} 0x200000 0x1600000; "\
 		"bootm ${initrd_addr};\0" \
 	"swu=1\0" \
-	"fit_config=conf@freescale_ap20-pt1.dtb\0"
+	"fit_config=conf-freescale_ap20-pt1.dtb\0"
 
 #ifndef CONFIG_FSPI_NOR_BOOTFLOW
 #define CONFIG_BOOTCOMMAND \


### PR DESCRIPTION
Configuration naming of fitimages has changed in
`meta/classes/kernel-fitimage.bbclass` in OE-core.
Adjust to it.