### PR TITLE
Cpu ready signal

### DIFF
--- a/board/variscite/imx8mm_var_dart/imx8mm_var_dart.c
+++ b/board/variscite/imx8mm_var_dart/imx8mm_var_dart.c
@@ -140,6 +140,8 @@ int board_early_init_f(void)
 
 	set_wdog_reset(wdog);
 
+	imx_iomux_v3_setup_multiple_pads(cpu_rdy_pads, ARRAY_SIZE(cpu_rdy_pads));
+
 	id = get_board_id();
 
 	if (id == DART_MX8M_MINI) {
@@ -214,8 +216,6 @@ static void setup_usb(void)
 
 void board_cli_init(void)
 {
-	imx_iomux_v3_setup_multiple_pads(cpu_rdy_pads, ARRAY_SIZE(cpu_rdy_pads));
-
 	gpio_request(CPU_RDY_GPIO, "cpu_rdy");
 	gpio_direction_output(CPU_RDY_GPIO, 1);
 }

--- a/board/variscite/imx8mm_var_dart/imx8mm_var_dart.c
+++ b/board/variscite/imx8mm_var_dart/imx8mm_var_dart.c
@@ -214,10 +214,15 @@ static void setup_usb(void)
 }
 #endif
 
-void board_cli_init(void)
+int board_mcu_set_cpu_ready(void)
 {
-	gpio_request(CPU_RDY_GPIO, "cpu_rdy");
-	gpio_direction_output(CPU_RDY_GPIO, 1);
+	int ret;
+
+	ret = gpio_request(CPU_RDY_GPIO, "cpu_rdy");
+	if (ret < 0)
+		return ret;
+
+	return gpio_direction_output(CPU_RDY_GPIO, 1);
 }
 
 int get_leica_board_id(char *data, int data_size)

--- a/common/cli.c
+++ b/common/cli.c
@@ -20,8 +20,6 @@
 
 DECLARE_GLOBAL_DATA_PTR;
 
-void __weak board_cli_init(void) {}
-
 #ifdef CONFIG_CMDLINE
 /*
  * Run a command using the selected parser.
@@ -226,7 +224,6 @@ err:
 void cli_loop(void)
 {
 	bootstage_mark(BOOTSTAGE_ID_ENTER_CLI_LOOP);
-	board_cli_init();
 #ifdef CONFIG_HUSH_PARSER
 	parse_file_outer();
 	/* This point is never reached */


### PR DESCRIPTION
CPU_READY pin is raised if we accidentally end up in CLI because all attempts to boot failed.
If a developer intends to access CLI, she needs to call `mcu_comm cpu_ready` in order to prevent MCU from rebooting CPU.