### PR TITLE
imx8mm-var-dart: add ap20-pt1-5 support

### DIFF
--- a/board/variscite/imx8mm_var_dart/imx8mm_var_dart.c
+++ b/board/variscite/imx8mm_var_dart/imx8mm_var_dart.c
@@ -273,7 +273,12 @@ int board_late_init(void)
 		else {
 			switch (board_id.board_index) {
 			case 'A':
+			case 'B':
+			case 'C':
 				env_set("leica_board", "AP20-PT1");
+				break;
+			case 'D':
+				env_set("leica_board", "AP20-PT1-5");
 				break;
 			default:
 				printf("Unknown Leica Board index: %c\n",


### PR DESCRIPTION
Add the support for AP20-PT1-5 including the new Leica board index "D"

Signed-off-by: Massimo Toscanelli <massimo.toscanelli@leica-geosystems.com>