### PR TITLE
Revert "configs: imx8mm-ap20: decrease bootdelay to 0"

### DIFF
--- a/configs/imx8mm_ap20_defconfig
+++ b/configs/imx8mm_ap20_defconfig
@@ -27,7 +27,7 @@ CONFIG_SPL_LOAD_FIT=y
 CONFIG_SPL_FIT_GENERATOR="arch/arm/mach-imx/mkimage_fit_atf.sh"
 CONFIG_OF_SYSTEM_SETUP=y
 CONFIG_SYS_EXTRA_OPTIONS="IMX_CONFIG=arch/arm/mach-imx/imx8m/imximage-8mm-lpddr4.cfg"
-CONFIG_BOOTDELAY=0
+CONFIG_BOOTDELAY=1
 CONFIG_AUTOBOOT_KEYED=y
 CONFIG_AUTOBOOT_PROMPT="Autobooting in %d seconds, press \"lll\" to stop\n"
 CONFIG_AUTOBOOT_STOP_STR="lll"

--- a/configs/imx8mm_ap20_fspi_defconfig
+++ b/configs/imx8mm_ap20_fspi_defconfig
@@ -25,7 +25,7 @@ CONFIG_SPL_LOAD_FIT=y
 CONFIG_SPL_FIT_GENERATOR="arch/arm/mach-imx/mkimage_fit_atf.sh"
 CONFIG_OF_SYSTEM_SETUP=y
 CONFIG_SYS_EXTRA_OPTIONS="IMX_CONFIG=arch/arm/mach-imx/imx8m/imximage-8mm-lpddr4-fspi.cfg"
-CONFIG_BOOTDELAY=0
+CONFIG_BOOTDELAY=1
 CONFIG_AUTOBOOT_KEYED=y
 CONFIG_AUTOBOOT_PROMPT="Autobooting in %d seconds, press \"lll\" to stop\n"
 CONFIG_AUTOBOOT_STOP_STR="lll"


### PR DESCRIPTION
This reverts commit f985fb53b347b1f87441ed0fb6146d9ac20f1675.

In order to recognise our 'lll' boot sequence, we cannot have a bootdelay
of 0 seconds, because the autoboot process is implemented as a do-while
loop that, with CONFIG_BOOTDELAY=0, terminates after reading just one char.
So, it is impossible to combine CONFIG_BOOTDELAY=0 and
CONFIG_AUTOBOOT_KEYED with CONFIG_AUTOBOOT_STOP_STR longer than 1.

https://github.com/hexagon-geo-surv/u-boot-imx/blob/3dece3a1c1c02b257ae2a2e3c7d770a3fb3949bb/common/autoboot.c#L190

We restore CONFIG_BOOTDELAY=1 so that we can read 'lll' and we are still
fast in booting the device.

Signed-off-by: Massimo Toscanelli <massimo.toscanelli@leica-geosystems.com>