### PR TITLE
common: leica-sep: terminate any possible characters sent to MCU

### DIFF
--- a/common/leica_sep.c
+++ b/common/leica_sep.c
@@ -39,6 +39,10 @@ static int leica_sep_transfer(struct leica_sep_funcs *f, char *cmd,
 	while(cmd[cmd_length] != ':' && cmd[cmd_length] != '\0')
 		cmd_length++;
 
+	/* Empty receiver FIFO before sending our command*/
+	while(f->tstc())
+		f->getc();
+
 	f->puts("\r\n");
 	f->puts(cmd);
 	cmd[1] = 'R';

--- a/common/leica_sep.c
+++ b/common/leica_sep.c
@@ -39,6 +39,7 @@ static int leica_sep_transfer(struct leica_sep_funcs *f, char *cmd,
 	while(cmd[cmd_length] != ':' && cmd[cmd_length] != '\0')
 		cmd_length++;
 
+	f->puts("\r\n");
 	f->puts(cmd);
 	cmd[1] = 'R';
 	while(get_timer(0) < (start + timeout_ms))
@@ -149,6 +150,7 @@ int leica_sep_send_ack(struct leica_sep_funcs *f, int boot_src)
 			return -1;
 	}
 
+	f->puts("\r\n");
 	f->puts(data);
 
 	return 0;

--- a/common/leica_sep.c
+++ b/common/leica_sep.c
@@ -53,7 +53,7 @@ static int leica_sep_transfer(struct leica_sep_funcs *f, char *cmd,
 			continue;
 
 		if (size <= bytes_received)
-			return -1;
+			break;
 
 		data[bytes_received] = f->getc();
 


### PR DESCRIPTION
We can not guarantee, that a possible transition on TX line of the UART
connection was interpreted as the start of a command by MCU.
Send termination characters before sending a command in order to make
sure that MCU interprets intentionally sent characters only.
