### PR TITLE
imx8mm_var-dart: fit_config: support ap20.dtb

### DIFF
--- a/include/configs/imx8mm_var_dart.h
+++ b/include/configs/imx8mm_var_dart.h
@@ -87,10 +87,12 @@
 		"bootm ${initrd_addr}#${fit_config};\0" \
 	"swu=1\0" \
 	"get_fit_config=leica_mcu_comm board_id board_id;" \
-		"if test \"${board_id}\" < \"D\"; then" \
-		"    echo !!! ERROR: Board with ID ${board_id} is not supported;" \
-		"else" \
-		"    env set fit_config conf-freescale_ap20.dtb;" \
+		"if test \"${board_id}\" < \"D\"; then " \
+		    "echo !!! ERROR: Board with ID ${board_id} is not supported; " \
+		"elif test -n \"${downgrade_dtb}\"; then " \
+		    "env set fit_config conf-freescale_${downgrade_dtb}; " \
+		"else " \
+		    "env set fit_config conf-freescale_ap20.dtb; " \
 		"fi\0"
 
 #ifndef CONFIG_FSPI_NOR_BOOTFLOW

--- a/include/configs/imx8mm_var_dart.h
+++ b/include/configs/imx8mm_var_dart.h
@@ -88,9 +88,9 @@
 	"swu=1\0" \
 	"get_fit_config=leica_mcu_comm board_id board_id;" \
 		"if test \"${board_id}\" < \"D\"; then" \
-		"    env set fit_config conf-freescale_ap20-pt1.dtb;" \
+		"    echo !!! ERROR: Board with ID ${board_id} is not supported;" \
 		"else" \
-		"    env set fit_config conf-freescale_ap20-pt1-5.dtb;" \
+		"    env set fit_config conf-freescale_ap20.dtb;" \
 		"fi\0"
 
 #ifndef CONFIG_FSPI_NOR_BOOTFLOW


### PR DESCRIPTION
ap20.dtb is a copy of ap20-pt1.5.dtb, it is a formal release name.
If board_id < D revision, u-boot will show "not support" and not boot again, others will boot from ap-20.dtb.
